### PR TITLE
fix(groups): disband not removing group from table

### DIFF
--- a/groups/server.lua
+++ b/groups/server.lua
@@ -283,6 +283,8 @@ local function initGroupObject(data)
 
         TriggerEvent("prp-bridge:server:groupDisbanded", private.uuid)
 
+        groups[private.uuid] = nil
+
         private.members = {}
         private.leader = nil
         private.activity = nil


### PR DESCRIPTION
Fix: Group disband not removing from groups table causing nil index crash



<img width="1316" height="1131" alt="image" src="https://github.com/user-attachments/assets/80fc84a4-29be-44a4-8a60-307494f3aebc" />

### Problem
`disband()` set `private = nil` but never removed the group from the `groups` lookup table. When `GetGroupByPartyUuid` iterated all groups, it called `getPartyUuid()` on a disbanded group whose `private` was already `nil`, causing:

This cascaded into `prp-drug-drops` failing with `export GetGroupByPartyUuid: nil`.

### Root Cause
1. Group gets disbanded → `private` set to `nil`, but group reference stays in `groups` table
2. `GetGroupByPartyUuid` iterates `groups`, hits the stale disbanded entry
3. Calls `group.getPartyUuid()` → accesses `private.partyUuid` → crash

### Fix
Added `groups[private.uuid] = nil` in `disband()` **before** nullifying `private`:

```lua
public.disband = function()
    for _, memberData in pairs(private.members) do
        memberToGroupMap[memberData.identifier] = nil
    end

    TriggerEvent("prp-bridge:server:groupDisbanded", private.uuid)

    groups[private.uuid] = nil  -- <- added this line

    private.members = {}
    private.leader = nil
    private.activity = nil

    private = nil
    public = nil
end
