### PR TITLE
feat(dispatch): Add lb-tablet dispatch integration

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -70,6 +70,7 @@ BridgeConfig.Medical = 'qbx_medical'
         - cd_dispatch
         - tk_dispatch
         - rcore_dispatch
+        - lb-tablet
 ]]
 ---@type AvailableDispatches
 BridgeConfig.Dispatch = "ps-dispatch"

--- a/modules/dispatch/lb-tablet/server.lua
+++ b/modules/dispatch/lb-tablet/server.lua
@@ -1,0 +1,33 @@
+local dispatch = {}
+
+---@param src number | string
+---@param coords vector3
+---@param jobs string[]
+---@param data AlertData
+---@param blip AlertBlip
+---@param alertFlash? boolean
+function dispatch.sendAlert(src, jobs, coords, data, blip, alertFlash)
+    -- Source: https://docs.lbscripts.com/tablet/script-integration/server-exports/
+    for i = 1, #jobs do
+        exports["lb-tablet"]:AddDispatch({
+            priority = "high",
+            code = data.code,
+            title = data.title,
+            description = data.description,
+            location = {
+                label = blip.text or data.title,
+                coords = vec2(coords.x, coords.y),
+            },
+            time = (data.length or blip.length or 5) * 60,
+            job = jobs[i],
+            blip = {
+                sprite = blip.sprite,
+                color = blip.colour,
+                size = blip.scale,
+                label = blip.text,
+            },
+        })
+    end
+end
+
+return dispatch

--- a/types/config.lua
+++ b/types/config.lua
@@ -10,7 +10,7 @@
 
 ---@alias AvailableMedicals 'qbx_medical' | 'esx_ambulancejob' | 'wasabi_ambulance' | 'ars_ambulancejob' | 'osp_ambulance' | 'p-ambulancejob' | 'nd_ambulance' | 'qb-ambulancejob'
 
----@alias AvailableDispatches 'ps-dispatch' | 'origen_police' | 'cd_dispatch' | 'rcore_dispatch' | 'tk_dispatch'
+---@alias AvailableDispatches 'ps-dispatch' | 'origen_police' | 'cd_dispatch' | 'rcore_dispatch' | 'tk_dispatch' | 'lb-tablet'
 
 ---@alias AvailableMinigames 'prp-minigames'
 


### PR DESCRIPTION
## Add lb-tablet dispatch integration

### Summary
- Added `lb-tablet` as a new dispatch module following the existing bridge pattern
- Maps the shared `AlertData`/`AlertBlip` parameters to lb-tablet's server-side `AddDispatch` export
- Loops per job since lb-tablet accepts a single job string, not an array

### Files Changed
- `modules/dispatch/lb-tablet/server.lua` (new)
