### PR TITLE
feat(medical): add randol_medical bridge

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -59,6 +59,7 @@ BridgeConfig.Target = "ox_target"
         - p-ambulancejob
         - nd_ambulance
         - qb-ambulancejob
+        - randol_medical
 ]]
 ---@type AvailableMedicals
 BridgeConfig.Medical = 'qbx_medical'

--- a/modules/medical/randol_medical/client.lua
+++ b/modules/medical/randol_medical/client.lua
@@ -1,0 +1,37 @@
+local medical = {}
+
+--- Source: https://randolio.gitbook.io/docs/paid-scripts/medical/exports
+
+---@param serverId number
+---@return boolean
+function medical.isPlayerDead(serverId)
+    local state = Player(serverId).state
+    return state?.dead or state?.laststand or false
+end
+
+---@param value number
+function medical.overrideMaxHealth(value)
+    -- Integrations with other resources
+end
+
+if bridge.name == bridge.currentResource then
+    AddStateBagChangeHandler('dead', ('player:%s'):format(cache.serverId), function(_bagName, _key, value)
+        if not value then
+            TriggerServerEvent("prp-bridge:server:revived")
+            TriggerEvent("prp-bridge:client:revived")
+            return
+        end
+
+        TriggerServerEvent("prp-bridge:server:died")
+        TriggerEvent("prp-bridge:client:died")
+    end)
+
+    AddStateBagChangeHandler('laststand', ('player:%s'):format(cache.serverId), function(_bagName, _key, value)
+        if not value then return end
+
+        TriggerServerEvent("prp-bridge:server:died")
+        TriggerEvent("prp-bridge:client:died")
+    end)
+end
+
+return medical

--- a/modules/medical/randol_medical/server.lua
+++ b/modules/medical/randol_medical/server.lua
@@ -1,0 +1,11 @@
+local medical = {}
+
+--- Source: https://randolio.gitbook.io/docs/paid-scripts/medical/exports
+
+---@param src number | string
+---@param amount number
+function medical.healPlayer(src, amount)
+    exports['randol_medical']:Heal(src)
+end
+
+return medical

--- a/types/config.lua
+++ b/types/config.lua
@@ -8,7 +8,7 @@
 
 ---@alias AvailableTargets 'ox_target' | 'qb-target' | 'sleepless_interact'
 
----@alias AvailableMedicals 'qbx_medical' | 'esx_ambulancejob' | 'wasabi_ambulance' | 'ars_ambulancejob' | 'osp_ambulance' | 'p-ambulancejob' | 'nd_ambulance' | 'qb-ambulancejob'
+---@alias AvailableMedicals 'qbx_medical' | 'esx_ambulancejob' | 'wasabi_ambulance' | 'ars_ambulancejob' | 'osp_ambulance' | 'p-ambulancejob' | 'nd_ambulance' | 'qb-ambulancejob' | 'randol_medical'
 
 ---@alias AvailableDispatches 'ps-dispatch' | 'origen_police' | 'cd_dispatch' | 'rcore_dispatch' | 'tk_dispatch'
 


### PR DESCRIPTION
## Summary
- Add **randol_medical** bridge module (client + server)
- Client: death/laststand detection via state bags (`dead`, `laststand`)
- Server: `healPlayer` calls `exports['randol_medical']:Heal(src)`
- Update `AvailableMedicals` type alias and config comments