### PR TITLE
feat(dispatch): add aty_dispatch, codem-dispatch, and core_dispatch bridges

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -70,6 +70,9 @@ BridgeConfig.Medical = 'qbx_medical'
         - cd_dispatch
         - tk_dispatch
         - rcore_dispatch
+        - aty_dispatch
+        - codem-dispatch
+        - core_dispatch
 ]]
 ---@type AvailableDispatches
 BridgeConfig.Dispatch = "ps-dispatch"

--- a/modules/dispatch/aty_dispatch/server.lua
+++ b/modules/dispatch/aty_dispatch/server.lua
@@ -1,0 +1,26 @@
+local dispatch = {}
+
+--- Source: https://forum.cfx.re/t/aty-disptach-advanced-disptach-system-free/5150150
+
+---@param src number | string
+---@param coords vector3
+---@param jobs string[]
+---@param data AlertData
+---@param blip AlertBlip
+---@param alertFlash? boolean
+function dispatch.sendAlert(src, jobs, coords, data, blip, alertFlash)
+    TriggerEvent("aty_dispatch:server:customDispatch",
+        data.title or "Alert",
+        data.code or "10-11",
+        { street = "", road = "" },
+        coords,
+        nil,
+        nil,
+        nil,
+        nil,
+        blip.sprite,
+        jobs
+    )
+end
+
+return dispatch

--- a/modules/dispatch/codem-dispatch/server.lua
+++ b/modules/dispatch/codem-dispatch/server.lua
@@ -1,0 +1,20 @@
+local dispatch = {}
+
+--- Source: https://codem.gitbook.io/codem-documentation/m-series/essentials/mmdt-aio/dispatch
+
+---@param src number | string
+---@param coords vector3
+---@param jobs string[]
+---@param data AlertData
+---@param blip AlertBlip
+---@param alertFlash? boolean
+function dispatch.sendAlert(src, jobs, coords, data, blip, alertFlash)
+    exports['codem-dispatch']:CustomDispatch({
+        type = data.code or 'General',
+        header = data.title,
+        text = data.description,
+        code = data.code,
+    })
+end
+
+return dispatch

--- a/modules/dispatch/core_dispatch/server.lua
+++ b/modules/dispatch/core_dispatch/server.lua
@@ -1,0 +1,27 @@
+local dispatch = {}
+
+--- Source: https://docs.c8re.store/core-dispatch/api
+
+---@param src number | string
+---@param coords vector3
+---@param jobs string[]
+---@param data AlertData
+---@param blip AlertBlip
+---@param alertFlash? boolean
+function dispatch.sendAlert(src, jobs, coords, data, blip, alertFlash)
+    for _, job in pairs(jobs) do
+        exports['core_dispatch']:sendAlert({
+            code = data.code,
+            message = data.description,
+            extraInfo = {},
+            coords = coords,
+            priority = alertFlash or false,
+            job = job,
+            time = (data.length or blip.length or 5) * 60000,
+            blip = blip.sprite,
+            color = blip.colour,
+        })
+    end
+end
+
+return dispatch

--- a/types/config.lua
+++ b/types/config.lua
@@ -10,7 +10,7 @@
 
 ---@alias AvailableMedicals 'qbx_medical' | 'esx_ambulancejob' | 'wasabi_ambulance' | 'ars_ambulancejob' | 'osp_ambulance' | 'p-ambulancejob' | 'nd_ambulance' | 'qb-ambulancejob'
 
----@alias AvailableDispatches 'ps-dispatch' | 'origen_police' | 'cd_dispatch' | 'rcore_dispatch' | 'tk_dispatch'
+---@alias AvailableDispatches 'ps-dispatch' | 'origen_police' | 'cd_dispatch' | 'rcore_dispatch' | 'tk_dispatch' | 'aty_dispatch' | 'codem-dispatch' | 'core_dispatch'
 
 ---@alias AvailableMinigames 'prp-minigames'
 


### PR DESCRIPTION
## Summary
- Add **aty_dispatch** bridge, triggers `aty_dispatch:server:customDispatch` server event directly
- Add **codem-dispatch** bridge, uses `exports['codem-dispatch']:CustomDispatch()` export
- Add **core_dispatch** bridge, uses `exports['core_dispatch']:sendAlert()` export
- Update `AvailableDispatches` type alias and config comments