### PR TITLE
Add mrnewbvehiclekeys support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ BridgeConfig = {
     Target      = "ox_target",       -- ox_target | qb-target | sleepless_interact
     Medical     = "qbx_medical",     -- qbx_medical | esx_ambulancejob | nd_ambulance
     Dispatch    = "ps-dispatch",     -- ps-dispatch | origen_police | cd_dispatch | rcore_dispatch
-    VehicleKeys = "qbx_vehiclekeys", -- qbx_vehiclekeys | cd_garage | mVehicle | okokGarage | wasabi_carlock | ...
+    VehicleKeys = "qbx_vehiclekeys", -- qbx_vehiclekeys | cd_garage | mVehicle | okokGarage | wasabi_carlock | mrnewbvehiclekeys | ...
     VehicleFuel = "ox_fuel",         -- ox_fuel | LegacyFuel | cdn-fuel | lc_fuel | qb-fuel
     Minigames   = "prp-minigames",
 

--- a/config.lua
+++ b/config.lua
@@ -90,6 +90,7 @@ BridgeConfig.Dispatch = "ps-dispatch"
         - vehicles_keys
         - wasabi_carlock
         - nd_core
+        - mrnewbvehiclekeys
 ]]
 ---@type AvailableVehicleKeys
 BridgeConfig.VehicleKeys = "qbx_vehiclekeys"

--- a/modules/vkeys/mrnewbvehiclekeys/client.lua
+++ b/modules/vkeys/mrnewbvehiclekeys/client.lua
@@ -1,0 +1,23 @@
+local vkeys = {}
+
+---@param vehicle number Vehicle entity
+---@param plate? string Vehicle plate
+function vkeys.give(vehicle, plate)
+    if not plate then
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+
+    return exports.MrNewbVehicleKeys:GiveKeysByPlate(plate)
+
+end
+
+---@param vehicle number Vehicle entity
+---@param plate? string Vehicle plate
+function vkeys.remove(vehicle, plate)
+    if not plate then
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+    exports.MrNewbVehicleKeys:RemoveKeysByPlate(plate)
+end
+
+return vkeys

--- a/modules/vkeys/mrnewbvehiclekeys/server.lua
+++ b/modules/vkeys/mrnewbvehiclekeys/server.lua
@@ -1,0 +1,25 @@
+local vkeys = {}
+
+---@param src number | string Player server id
+---@param vehicle number Vehicle entity
+---@param plate? string Vehicle plate
+function vkeys.give(src, vehicle, plate)
+    if not plate then
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+
+    exports.MrNewbVehicleKeys:GiveKeysByPlate(src, plate)
+end
+
+---@param src number | string Player server id
+---@param vehicle number Vehicle entity
+---@param plate? string Vehicle plate
+function vkeys.remove(src, vehicle, plate)
+    if not plate then
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+
+    exports.MrNewbVehicleKeys:RemoveKeysByPlate(src, plate)
+end
+
+return vkeys

--- a/types/config.lua
+++ b/types/config.lua
@@ -14,7 +14,7 @@
 
 ---@alias AvailableMinigames 'prp-minigames'
 
----@alias AvailableVehicleKeys 'cd_garage' | 'mVehicle' | 'okokGarage' | 'qb-vehiclekeys' | 'qbx_vehiclekeys' | 'vehicles_keys' | 'wasabi_carlock' | 'nd_core'
+---@alias AvailableVehicleKeys 'cd_garage' | 'mVehicle' | 'okokGarage' | 'qb-vehiclekeys' | 'qbx_vehiclekeys' | 'vehicles_keys' | 'wasabi_carlock' | 'nd_core' | 'mrnewbvehiclekeys'
 
 ---@alias VehicleClasses 'X' | 'S' | 'A' | 'B' | 'C' | 'D' | 'E' | 'EV1' | 'EV2'
 ---@alias VehicleTypes 'car' | 'bike' | 'quadbike' | 'bicycle' | 'heli' | 'plane' | 'boat' | 'trailer' | 'train' | 'blimp' | 'submarine' | 'submarinecar' | 'amphibious_quadbike' | 'amphibious_automobile'


### PR DESCRIPTION
Register mrnewbvehiclekeys as an available vehicle-keys provider and add client/server wrappers.

- Added modules/vkeys/mrnewbvehiclekeys/client.lua and server.lua implementing give/remove helpers that call MrNewbVehicleKeys exports (GiveKeysByPlate / RemoveKeysByPlate).
- Updated types/config.lua to include 'mrnewbvehiclekeys' in AvailableVehicleKeys union.
- Updated config.lua and README.md to document and list mrnewbvehiclekeys as an option for BridgeConfig.VehicleKeys.

This integrates the MrNewbVehicleKeys provider into the bridge so it can be selected as the vehicle-keys backend.