### PR TITLE
Add gksphone, Renewed-Fuel/Vehiclekeys and ambulance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ BridgeConfig = {
 
     -- External systems
     Inventory   = "ox_inventory",    -- ox_inventory | origen_inventory | tgiann_inventory
-    Phone       = "lb-phone",        -- lb-phone | yseries | yphone | yflip | npwd | roadphone | 17mov_phone
+    Phone       = "lb-phone",        -- lb-phone | yseries | yphone | yflip | npwd | roadphone | 17mov_phone | gksphone
     Target      = "ox_target",       -- ox_target | qb-target | sleepless_interact
     Medical     = "qbx_medical",     -- qbx_medical | esx_ambulancejob | nd_ambulance
     Dispatch    = "ps-dispatch",     -- ps-dispatch | origen_police | cd_dispatch | rcore_dispatch
-    VehicleKeys = "qbx_vehiclekeys", -- qbx_vehiclekeys | cd_garage | mVehicle | okokGarage | wasabi_carlock | mrnewbvehiclekeys | ...
-    VehicleFuel = "ox_fuel",         -- ox_fuel | LegacyFuel | cdn-fuel | lc_fuel | qb-fuel
+    VehicleKeys = "qbx_vehiclekeys", -- qbx_vehiclekeys | cd_garage | mVehicle | okokGarage | wasabi_carlock | mrnewbvehiclekeys | Renewed-Vehiclekeys | ...
+    VehicleFuel = "ox_fuel",         -- ox_fuel | LegacyFuel | cdn-fuel | lc_fuel | qb-fuel | Renewed-Fuel
     Minigames   = "prp-minigames",
 
     -- Group command

--- a/config.lua
+++ b/config.lua
@@ -36,6 +36,7 @@ BridgeConfig.Inventory = "ox_inventory"
         - npwd
         - roadphone
         - 17mov_phone
+        - gksphone
 ]]
 ---@type AvailablePhones
 BridgeConfig.Phone = "lb-phone"
@@ -91,9 +92,10 @@ BridgeConfig.Dispatch = "ps-dispatch"
         - wasabi_carlock
         - nd_core
         - mrnewbvehiclekeys
+        - Renewed-Vehiclekeys
 ]]
 ---@type AvailableVehicleKeys
-BridgeConfig.VehicleKeys = "qbx_vehiclekeys"
+BridgeConfig.VehicleKeys = "Renewed-Vehiclekeys"
 
 --[[
     AvailableVehicleFuel Resources:
@@ -102,6 +104,7 @@ BridgeConfig.VehicleKeys = "qbx_vehiclekeys"
         - cdn-fuel
         - lc_fuel
         - qb-fuel
+        - Renewed-Fuel
 ]]
 ---@type AvailableVehicleFuel
 BridgeConfig.VehicleFuel = "ox_fuel"

--- a/modules/medical/p-ambulancejob/client.lua
+++ b/modules/medical/p-ambulancejob/client.lua
@@ -1,0 +1,43 @@
+local medical = {}
+
+---@param serverId number
+---@return boolean
+function medical.isPlayerDead(serverId)
+    local state = Player(serverId).state
+    return state?.isDead or state?.dead or false
+end
+
+---@param value number
+function medical.overrideMaxHealth(value)
+    -- Integrations with other resources
+end
+
+if bridge.name == bridge.currentResource then
+    local cachedDeadState
+
+    ---@param value any
+    local function syncDeathState(value)
+        local isDead = value == true
+        if cachedDeadState == isDead then return end
+        cachedDeadState = isDead
+
+        if not isDead then
+            TriggerServerEvent("prp-bridge:server:revived")
+            TriggerEvent("prp-bridge:client:revived")
+            return
+        end
+
+        TriggerServerEvent("prp-bridge:server:died")
+        TriggerEvent("prp-bridge:client:died")
+    end
+
+    AddStateBagChangeHandler('isDead', ('player:%s'):format(cache.serverId), function(_bagName, _key, value)
+        syncDeathState(value)
+    end)
+
+    AddStateBagChangeHandler('dead', ('player:%s'):format(cache.serverId), function(_bagName, _key, value)
+        syncDeathState(value)
+    end)
+end
+
+return medical

--- a/modules/medical/p-ambulancejob/server.lua
+++ b/modules/medical/p-ambulancejob/server.lua
@@ -1,0 +1,12 @@
+local medical = {}
+
+---@param src number | string
+---@param amount number
+function medical.healPlayer(src, amount)
+    local target = tonumber(src)
+    if not target then return end
+
+    TriggerClientEvent('p_ambulancejob/client/death/revive', target)
+end
+
+return medical

--- a/modules/phone/gksphone/server.lua
+++ b/modules/phone/gksphone/server.lua
@@ -1,0 +1,47 @@
+local phone = {}
+
+---@param src number
+---@param from number
+---@param message string
+function phone.sendMessage(src, from, message)
+    local phoneNumber = exports["gksphone"]:GetPhoneBySource(src)
+    if not phoneNumber then
+        return false
+    end
+
+    local result = exports["gksphone"]:SendMessage(tostring(from), tostring(phoneNumber), message)
+    return (result and result.status) or false
+end
+
+---@param src number | string
+---@param from number
+---@param coords vector3
+function phone.sendCoords(src, from, coords)
+    local phoneNumber = exports["gksphone"]:GetPhoneBySource(src)
+    if not phoneNumber then
+        return false
+    end
+
+    local result = exports["gksphone"]:SendMessage(tostring(from), tostring(phoneNumber), {
+        x = coords.x,
+        y = coords.y
+    })
+
+    return (result and result.status) or false
+end
+
+---@param src number
+---@param title string
+---@param content? string
+function phone.sendNotification(src, title, content)
+    exports["gksphone"]:sendNotification(src, {
+        title = title,
+        message = content or "",
+        icon = '/html/img/icons/messages.png',
+        duration = 5000,
+        type = "info",
+        buttonactive = false
+    })
+end
+
+return phone

--- a/modules/vfuel/Renewed-Fuel/client.lua
+++ b/modules/vfuel/Renewed-Fuel/client.lua
@@ -1,0 +1,3 @@
+local vfuel = {}
+
+return vfuel

--- a/modules/vfuel/Renewed-Fuel/server.lua
+++ b/modules/vfuel/Renewed-Fuel/server.lua
@@ -1,0 +1,16 @@
+local vfuel = {}
+
+---@param source number
+---@param vehicle number
+---@param amount number
+---@return boolean
+function vfuel.set(source, vehicle, amount)
+    if not vehicle or not DoesEntityExist(vehicle) then
+        return false
+    end
+
+    exports['Renewed-Fuel']:SetFuel(vehicle, amount)
+    return true
+end
+
+return vfuel

--- a/modules/vkeys/Renewed-Vehiclekeys/client.lua
+++ b/modules/vkeys/Renewed-Vehiclekeys/client.lua
@@ -1,0 +1,23 @@
+local vkeys = {}
+
+---@param vehicle number Vehicle entity
+---@param plate? string Vehicle plate
+function vkeys.give(vehicle, plate)
+    if not plate then
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+
+    exports['Renewed-Vehiclekeys']:addKey(plate)
+end
+
+---@param vehicle number Vehicle entity
+---@param plate? string Vehicle plate
+function vkeys.remove(vehicle, plate)
+    if not plate then
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+
+    exports['Renewed-Vehiclekeys']:removeKey(plate)
+end
+
+return vkeys

--- a/modules/vkeys/Renewed-Vehiclekeys/server.lua
+++ b/modules/vkeys/Renewed-Vehiclekeys/server.lua
@@ -1,0 +1,25 @@
+local vkeys = {}
+
+---@param src number | string Player server id
+---@param vehicle number Vehicle entity
+---@param plate? string Vehicle plate
+function vkeys.give(src, vehicle, plate)
+    if not plate then
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+
+    exports['Renewed-Vehiclekeys']:addKey(src, plate)
+end
+
+---@param src number | string Player server id
+---@param vehicle number Vehicle entity
+---@param plate? string Vehicle plate
+function vkeys.remove(src, vehicle, plate)
+    if not plate then
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+
+    exports['Renewed-Vehiclekeys']:removeKey(src, plate)
+end
+
+return vkeys

--- a/types/config.lua
+++ b/types/config.lua
@@ -4,7 +4,7 @@
 
 ---@alias AvailableInventories 'ox_inventory' | 'qb-inventory' | 'origen_inventory' | 'tgiann-inventory'
 
----@alias AvailablePhones 'lb-phone' | 'yseries' | 'yphone' | 'yflip' | 'npwd' | 'roadphone' | '17mov_phone'
+---@alias AvailablePhones 'lb-phone' | 'yseries' | 'yphone' | 'yflip' | 'npwd' | 'roadphone' | '17mov_phone' | 'gksphone'
 
 ---@alias AvailableTargets 'ox_target' | 'qb-target' | 'sleepless_interact'
 
@@ -14,7 +14,7 @@
 
 ---@alias AvailableMinigames 'prp-minigames'
 
----@alias AvailableVehicleKeys 'cd_garage' | 'mVehicle' | 'okokGarage' | 'qb-vehiclekeys' | 'qbx_vehiclekeys' | 'vehicles_keys' | 'wasabi_carlock' | 'nd_core' | 'mrnewbvehiclekeys'
+---@alias AvailableVehicleKeys 'cd_garage' | 'mVehicle' | 'okokGarage' | 'qb-vehiclekeys' | 'qbx_vehiclekeys' | 'vehicles_keys' | 'wasabi_carlock' | 'nd_core' | 'mrnewbvehiclekeys' | 'Renewed-Vehiclekeys'
 
 ---@alias VehicleClasses 'X' | 'S' | 'A' | 'B' | 'C' | 'D' | 'E' | 'EV1' | 'EV2'
 ---@alias VehicleTypes 'car' | 'bike' | 'quadbike' | 'bicycle' | 'heli' | 'plane' | 'boat' | 'trailer' | 'train' | 'blimp' | 'submarine' | 'submarinecar' | 'amphibious_quadbike' | 'amphibious_automobile'
@@ -27,4 +27,4 @@
 ---@field type VehicleTypes
 ---@field inBoosting boolean
 
----@alias AvailableVehicleFuel 'ox_fuel' | 'LegacyFuel' | 'cdn-fuel' | 'lc_fuel' | 'qb-fuel'
+---@alias AvailableVehicleFuel 'ox_fuel' | 'LegacyFuel' | 'cdn-fuel' | 'lc_fuel' | 'qb-fuel' | 'Renewed-Fuel'


### PR DESCRIPTION
Add integrations and modules for new external resources and ambulance support. Introduces p-ambulancejob client/server to sync player death state and trigger revive events; adds gksphone server adapter (sendMessage, sendCoords, sendNotification); adds Renewed-Fuel and Renewed-Vehiclekeys client/server modules for fuel and key management. Update config, types and README to include gksphone, Renewed-Fuel and Renewed-Vehiclekeys and set VehicleKeys default to Renewed-Vehiclekeys.