### PR TITLE
fix(cooldowns): resolve key mismatch and variable shadowing

### DIFF
--- a/cooldowns/server.lua
+++ b/cooldowns/server.lua
@@ -25,11 +25,6 @@ exports('startGlobalCooldown', startGlobalCooldown)
 local function startCooldownByIdentifier(identifier, cooldownKey, minutes, applyToAllCharacters)
     local cooldownIdentifier = ('character-%s-%s'):format(identifier, cooldownKey)
 
-    if applyToAllCharacters then
-        local source = bridge.fw.getSrcFromIdentifier(identifier)
-        cooldownIdentifier = ('player-%s-%s'):format(source, cooldownKey)
-    end
-
     if cooldowns[cooldownIdentifier] then
         lib.print.debug('Tried to start a player cooldown that already exists', identifier, cooldownKey,
             minutes,

--- a/utils/lootGenerator.lua
+++ b/utils/lootGenerator.lua
@@ -54,7 +54,7 @@ local function GenerateLoot(pool, itemCount, guaranteedRarities)
                     local chosenItem = getRandomItemFromList(itemsOfRarity)
 
                     if chosenItem then
-                        local count = math.random(
+                        local itemAmt = math.random(
                             chosenItem.min or 1,
                             chosenItem.max or 1
                         )
@@ -63,7 +63,7 @@ local function GenerateLoot(pool, itemCount, guaranteedRarities)
                             loot,
                             {
                                 name = chosenItem.name,
-                                count = count,
+                                count = itemAmt,
                                 metadata = chosenItem.metadata or {},
                                 rarity = rarity,
                             }


### PR DESCRIPTION
## Description
resolved two bugs 

1. **Cooldown Key Mismatch**: Fixed a bug where `applyToAllCharacters = true` stored cooldowns under a `player-` prefix that was never checked by `isCooldownActiveForIdentifier`, effectively disabling them.
2. **Variable Shadowing**: Renamed a local variable in the loot generator to avoid shadowing an outer loop bound.

