### PR TITLE
fix(queue/sea): add missing check before print

### DIFF
--- a/uniqueue/classes/queue.lua
+++ b/uniqueue/classes/queue.lua
@@ -429,7 +429,9 @@ function CreateUniqueue(name, type, requiredPolicePower, maxConcurrentTasks, coo
             QueuePrint(private.name, "^5Max concurrent tasks reached")
         end
 
-        QueuePrint(private.name, "^6Current Tasks:^7 " .. json.encode(private.executingTasks, { indent = true }))
+        if QueueDevMode then
+            QueuePrint(private.name, "^6Current Tasks:^7 " .. json.encode(private.executingTasks, { indent = true }))
+        end
         QueuePrint(private.name, "^6Free police strength: " .. tostring(GetFreePolicePower()) .. "^7")
 
         private.unlock()


### PR DESCRIPTION
This was causing players that was in the queue to have a issue:

<img width="1334" height="500" alt="image" src="https://github.com/user-attachments/assets/0d603b33-0c88-4e42-81e8-19b76c545ef5" />
