### PR TITLE
Fix client-trust issues in item usage, sell shops, and qbx medical sync

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 "yes"
 
 author "Prodigy Studios"
 description "prp-bridge - A framework bridge for Prodigy Studios resources"
-version "1.0.4"
+version "1.1.2"
 
 ui_page "ui/index.html"
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 "yes"
 
 author "Prodigy Studios"
 description "prp-bridge - A framework bridge for Prodigy Studios resources"
-version "1.1.0"
+version "1.1.1"
 
 ui_page "ui/index.html"
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 "yes"
 
 author "Prodigy Studios"
 description "prp-bridge - A framework bridge for Prodigy Studios resources"
-version "1.0.2"
+version "1.0.4"
 
 ui_page "ui/index.html"
 

--- a/modules/fw/nd_core/server.lua
+++ b/modules/fw/nd_core/server.lua
@@ -252,15 +252,19 @@ end
 
 ---@type table<string, fun(src: number, item: { name: string, label: string, metaData: table?, slot: number, count: number })>
 local itemsRegistry = {}
-RegisterNetEvent("ox_inventory:usedItemInternal", function(slot)
-    local src = source
+---@type table<string, string>
+local itemUseHooks = {}
 
-    local item = bridge.inv.getSlot(src, slot)
-    if not item then return lib.print.debug("Item not found in slot:", slot) end
+local function dispatchRegisteredItemUse(success, payload)
+    if not success or type(payload) ~= "table" or type(payload.item) ~= "table" then
+        return
+    end
 
-    lib.print.debug(('prp-bridge: Player %d used item %s from slot %d'):format(src, json.encode(item, { indent = true }), slot))
+    local item = payload.item
     local handler = itemsRegistry[item.name]
     if not handler then return lib.print.debug("No handler found for item:", item.name) end
+
+    lib.print.debug(('prp-bridge: Player %d used item %s from slot %d'):format(payload.source, json.encode(item, { indent = true }), item.slot))
 
     local data = {
         name = item.name,
@@ -270,17 +274,30 @@ RegisterNetEvent("ox_inventory:usedItemInternal", function(slot)
         count = item.count,
     }
 
-    local s, e = pcall(handler, src, data)
+    local s, e = pcall(handler, payload.source, data)
     if not s then
         lib.print.debug(("prp-bridge: Error in item usage handler for item '%s': %s"):format(item.name, e))
     end
-end)
+end
 
 ---@param itemName string
 ---@param cb fun(src: number, item: { name: string, label: string, metaData: table?, slot: number, count: number })
 function fw.registerItemUse(itemName, cb)
     lib.print.debug('Registering item use for item:', itemName)
     itemsRegistry[itemName] = cb
+
+    if itemUseHooks[itemName] then
+        return
+    end
+
+    local hookId = exports.ox_inventory:registerHook("usingItem", nil, {
+        itemFilter = {
+            [itemName] = true,
+        }
+    })
+
+    itemUseHooks[itemName] = hookId
+    AddEventHandler(hookId, dispatchRegisteredItemUse)
 end
 
 ---@param plate string

--- a/modules/fw/nd_core/server.lua
+++ b/modules/fw/nd_core/server.lua
@@ -256,9 +256,7 @@ local itemsRegistry = {}
 local itemUseHooks = {}
 
 local function dispatchRegisteredItemUse(success, payload)
-    if not success or type(payload) ~= "table" or type(payload.item) ~= "table" then
-        return
-    end
+    if not success then return end
 
     local item = payload.item
     local handler = itemsRegistry[item.name]

--- a/modules/fw/ox_core/server.lua
+++ b/modules/fw/ox_core/server.lua
@@ -380,9 +380,7 @@ local itemsRegistry = {}
 local itemUseHooks = {}
 
 local function dispatchRegisteredItemUse(success, payload)
-    if not success or type(payload) ~= "table" or type(payload.item) ~= "table" then
-        return
-    end
+    if not success then return end
 
     local item = payload.item
     local handler = itemsRegistry[item.name]

--- a/modules/fw/ox_core/server.lua
+++ b/modules/fw/ox_core/server.lua
@@ -376,15 +376,19 @@ end
 
 ---@type table<string, fun(src: number, item: { name: string, label: string, metaData: table?, slot: number, count: number })>
 local itemsRegistry = {}
-RegisterNetEvent("ox_inventory:usedItemInternal", function(slot)
-    local src = source
+---@type table<string, string>
+local itemUseHooks = {}
 
-    local item = bridge.inv.getSlot(src, slot)
-    if not item then return lib.print.debug("Item not found in slot:", slot) end
+local function dispatchRegisteredItemUse(success, payload)
+    if not success or type(payload) ~= "table" or type(payload.item) ~= "table" then
+        return
+    end
 
-    lib.print.debug(("prp-bridge: Player %d used item %s from slot %d"):format(src, json.encode(item, { indent = true }), slot))
+    local item = payload.item
     local handler = itemsRegistry[item.name]
     if not handler then return lib.print.debug("No handler found for item:", item.name) end
+
+    lib.print.debug(("prp-bridge: Player %d used item %s from slot %d"):format(payload.source, json.encode(item, { indent = true }), item.slot))
 
     local data = {
         name = item.name,
@@ -394,17 +398,30 @@ RegisterNetEvent("ox_inventory:usedItemInternal", function(slot)
         count = item.count,
     }
 
-    local s, e = pcall(handler, src, data)
+    local s, e = pcall(handler, payload.source, data)
     if not s then
         lib.print.debug(("prp-bridge: Error in item usage handler for item '%s': %s"):format(item.name, e))
     end
-end)
+end
 
 ---@param itemName string
 ---@param cb fun(src: number, item: { name: string, label: string, metaData: table?, slot: number, count: number })
 function fw.registerItemUse(itemName, cb)
     lib.print.debug("Registering item use for item:", itemName)
     itemsRegistry[itemName] = cb
+
+    if itemUseHooks[itemName] then
+        return
+    end
+
+    local hookId = exports.ox_inventory:registerHook("usingItem", nil, {
+        itemFilter = {
+            [itemName] = true,
+        }
+    })
+
+    itemUseHooks[itemName] = hookId
+    AddEventHandler(hookId, dispatchRegisteredItemUse)
 end
 
 ---@param plate string

--- a/modules/medical/qbx_medical/client.lua
+++ b/modules/medical/qbx_medical/client.lua
@@ -12,16 +12,32 @@ function medical.overrideMaxHealth(value)
 end
 
 if bridge.name == bridge.currentResource then
+    local deathState = {
+        isdead = false,
+        inlaststand = false,
+    }
+    local cachedDeadState = false
+
     RegisterNetEvent("qbx_core:client:onSetMetaData", function(key, _, value)
         if key ~= "isdead" and key ~= "inlaststand" then return end
-        if value == true or value == "true" then
-            TriggerServerEvent("prp-bridge:server:revived")
-            TriggerEvent("prp-bridge:client:revived")
+
+        deathState[key] = value == true or value == "true"
+
+        local isDead = deathState.isdead or deathState.inlaststand
+        if cachedDeadState == isDead then
             return
         end
 
-        TriggerServerEvent("prp-bridge:server:died")
-        TriggerEvent("prp-bridge:client:died")
+        cachedDeadState = isDead
+
+        if isDead then
+            TriggerServerEvent("prp-bridge:server:died")
+            TriggerEvent("prp-bridge:client:died")
+            return
+        end
+
+        TriggerServerEvent("prp-bridge:server:revived")
+        TriggerEvent("prp-bridge:client:revived")
     end)
 end
 

--- a/sellshops/server.lua
+++ b/sellshops/server.lua
@@ -1,4 +1,22 @@
 local shops = {}
+local DEFAULT_SELL_SHOP_DISTANCE <const> = 5.0
+
+local function isPlayerNearShop(src, shop)
+    if not shop or not shop.coords then
+        return false
+    end
+
+    local ped = GetPlayerPed(src)
+    if not DoesEntityExist(ped) then
+        return false
+    end
+
+    local playerCoords = GetEntityCoords(ped)
+    local shopCoords = vector3(shop.coords.x, shop.coords.y, shop.coords.z)
+    local maxDistance = shop.distance or shop.maxDistance or DEFAULT_SELL_SHOP_DISTANCE
+
+    return #(playerCoords - shopCoords) <= maxDistance
+end
 
 bridge.inv.registerSwapItemsHook(function(payload)
     local src = payload.source
@@ -23,6 +41,10 @@ bridge.inv.registerSwapItemsHook(function(payload)
 
     local shop = shops[inventory]
     if not shop then
+        return false
+    end
+
+    if not isPlayerNearShop(src, shop) then
         return false
     end
 
@@ -80,6 +102,10 @@ local function openShop(src, id)
 
     if not shop then
         lib.print.error(("No shop found with id %s"):format(shopId))
+        return
+    end
+
+    if not isPlayerNearShop(src, shop) then
         return
     end
 


### PR DESCRIPTION
- Replace client-triggered item usage handling with ox_inventory server-side usingItem post-hooks.
- Validate sell shop distance server-side before opening stashes and before paying item sales.
- Correct qbx_medical death state sync so died/revived events match isdead/inlaststand metadata.