### PR TITLE
feat: add qs-dispatch and qs-smartphone-pro bridge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ BridgeConfig = {
 
     -- External systems
     Inventory   = "ox_inventory",    -- ox_inventory | origen_inventory | tgiann_inventory
-    Phone       = "lb-phone",        -- lb-phone | yseries | yphone | yflip | npwd | roadphone | 17mov_phone | gksphone
+    Phone       = "lb-phone",        -- lb-phone | yseries | yphone | yflip | npwd | roadphone | 17mov_phone | gksphone qs-smartphone-pro
     Target      = "ox_target",       -- ox_target | qb-target | sleepless_interact
     Medical     = "qbx_medical",     -- qbx_medical | esx_ambulancejob | nd_ambulance
-    Dispatch    = "ps-dispatch",     -- ps-dispatch | origen_police | cd_dispatch | rcore_dispatch
+    Dispatch    = "ps-dispatch",     -- ps-dispatch | origen_police | cd_dispatch | rcore_dispatch | qs-dispatch
     VehicleKeys = "qbx_vehiclekeys", -- qbx_vehiclekeys | cd_garage | mVehicle | okokGarage | wasabi_carlock | mrnewbvehiclekeys | Renewed-Vehiclekeys | ...
     VehicleFuel = "ox_fuel",         -- ox_fuel | LegacyFuel | cdn-fuel | lc_fuel | qb-fuel | Renewed-Fuel
     Minigames   = "prp-minigames",
@@ -78,7 +78,7 @@ modules/
 ├── fw/          # frameworks  (qbx_core, ox_core, qb-core, es_extended, nd_core)
 ├── inv/         # inventories (ox_inventory, origen_inventory, tgiann_inventory)
 ├── target/      # targeting   (ox_target, qb-target, sleepless_interact)
-├── dispatch/    # dispatch    (ps-dispatch, origen_police, cd_dispatch, rcore_dispatch)
+├── dispatch/    # dispatch    (ps-dispatch, origen_police, cd_dispatch, rcore_dispatch, qs-dispatch)
 ├── medical/     # medical     (qbx_medical, esx_ambulancejob, nd_ambulance)
 ├── phone/       # phones      (lb-phone, yseries, yphone, npwd, ...)
 ├── vkeys/       # vehicle keys

--- a/config.lua
+++ b/config.lua
@@ -17,7 +17,7 @@ BridgeConfig.Debug = true
         - nd_core
 ]]
 ---@type AvailableFrameworks
-BridgeConfig.FrameWork = "qbx_core"
+BridgeConfig.FrameWork = "es_extended"
 
 --[[
     Available inventories
@@ -39,9 +39,10 @@ BridgeConfig.Inventory = "ox_inventory"
         - 17mov_phone
         - gksphone
         - meteo-phone
+        - qs-smartphone-pro
 ]]
 ---@type AvailablePhones
-BridgeConfig.Phone = "lb-phone"
+BridgeConfig.Phone = "qs-smartphone-pro"
 
 --[[
     Available targets
@@ -79,9 +80,10 @@ BridgeConfig.Medical = 'qbx_medical'
         - codem-dispatch
         - core_dispatch
         - kartik-mdt
+        - qs-dispatch
 ]]
 ---@type AvailableDispatches
-BridgeConfig.Dispatch = "ps-dispatch"
+BridgeConfig.Dispatch = "qs-dispatch"
 
 --[[
     AvailableVehicleKeys Resources:

--- a/config.lua
+++ b/config.lua
@@ -17,7 +17,7 @@ BridgeConfig.Debug = true
         - nd_core
 ]]
 ---@type AvailableFrameworks
-BridgeConfig.FrameWork = "es_extended"
+BridgeConfig.FrameWork = "qbx_core"
 
 --[[
     Available inventories
@@ -42,7 +42,7 @@ BridgeConfig.Inventory = "ox_inventory"
         - qs-smartphone-pro
 ]]
 ---@type AvailablePhones
-BridgeConfig.Phone = "qs-smartphone-pro"
+BridgeConfig.Phone = "lb-phone"
 
 --[[
     Available targets
@@ -83,7 +83,7 @@ BridgeConfig.Medical = 'qbx_medical'
         - qs-dispatch
 ]]
 ---@type AvailableDispatches
-BridgeConfig.Dispatch = "qs-dispatch"
+BridgeConfig.Dispatch = "ps-dispatch"
 
 --[[
     AvailableVehicleKeys Resources:

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 "yes"
 
 author "Prodigy Studios"
 description "prp-bridge - A framework bridge for Prodigy Studios resources"
-version "1.1.1"
+version "1.1.4"
 
 ui_page "ui/index.html"
 

--- a/modules/dispatch/qs-dispatch/server.lua
+++ b/modules/dispatch/qs-dispatch/server.lua
@@ -1,0 +1,31 @@
+local dispatch = {}
+
+---@param src number | string
+---@param coords vector3
+---@param jobs string[]
+---@param data AlertData
+---@param blip AlertBlip
+---@param alertFlash? boolean
+function dispatch.sendAlert(src, jobs, coords, data, blip, alertFlash)
+    -- Source: https://www.quasar-store.com/docs/dispatch-and-mdt/commands-and-exports
+    TriggerEvent("qs-dispatch:server:CreateDispatchCall", {
+        job = jobs,
+        callLocation = coords,
+        callCode = {
+            code = data.code,
+            snippet = data.title,
+        },
+        message = data.description,
+        flashes = alertFlash,
+        blip = {
+            sprite = blip.sprite,
+            scale = blip.scale,
+            colour = blip.colour,
+            flashes = blip.flash,
+            text = blip.text,
+            time = (data.length and data.length * 60 * 1000) or (blip.length and blip.length * 1000),
+        },
+    })
+end
+
+return dispatch

--- a/modules/phone/qs-smartphone-pro/server.lua
+++ b/modules/phone/qs-smartphone-pro/server.lua
@@ -4,7 +4,7 @@ local phone = {}
 ---@param from number
 ---@param message string
 function phone.sendMessage(src, from, message)
-    -- Source: https://www.quasar-store.com/docs/smartphone
+      -- Source: https://www.quasar-store.com/docs ( no documentation for smartphone pro )
     local ok = exports["qs-smartphone-pro"]:sendNewMail(src, {
         sender = tostring(from),
         subject = "Message",
@@ -20,7 +20,7 @@ end
 function phone.sendCoords(src, from, coords)
     -- No dedicated "share location + waypoint button" export confirmed for qs-smartphone-pro,
     -- so we send the coordinates as a readable mail instead (safe fallback).
-    -- Source: https://www.quasar-store.com/docs/smartphone 
+    -- Source: https://www.quasar-store.com/docs ( no documentation for smartphone pro )
     local ok = exports["qs-smartphone-pro"]:sendNewMail(src, {
         sender = tostring(from),
         subject = "Location",
@@ -34,7 +34,8 @@ end
 ---@param title string
 ---@param content? string
 function phone.sendNotification(src, title, content)
-    -- Source: https://www.quasar-store.com/docs/smartphone 
+    -- Source: https://www.quasar-store.com/docs ( no documentation for smartphone pro )
+    -- Confirmed working on our qs-smartphone-pro install (tested)
     local identifier = GetPlayerIdentifier(src, 0)
     local phoneNumber = exports["qs-smartphone-pro"]:GetPhoneNumberFromIdentifier(identifier, false)
 

--- a/modules/phone/qs-smartphone-pro/server.lua
+++ b/modules/phone/qs-smartphone-pro/server.lua
@@ -1,0 +1,54 @@
+local phone = {}
+
+---@param src number
+---@param from number
+---@param message string
+function phone.sendMessage(src, from, message)
+    -- Source: https://www.quasar-store.com/docs/smartphone
+    local ok = exports["qs-smartphone-pro"]:sendNewMail(src, {
+        sender = tostring(from),
+        subject = "Message",
+        message = message,
+    })
+
+    return ok ~= false
+end
+
+---@param src number
+---@param from number
+---@param coords vector3
+function phone.sendCoords(src, from, coords)
+    -- No dedicated "share location + waypoint button" export confirmed for qs-smartphone-pro,
+    -- so we send the coordinates as a readable mail instead (safe fallback).
+    -- Source: https://www.quasar-store.com/docs/smartphone 
+    local ok = exports["qs-smartphone-pro"]:sendNewMail(src, {
+        sender = tostring(from),
+        subject = "Location",
+        message = ("A location has been shared with you: %.2f, %.2f, %.2f"):format(coords.x, coords.y, coords.z),
+    })
+
+    return ok ~= false
+end
+
+---@param src number
+---@param title string
+---@param content? string
+function phone.sendNotification(src, title, content)
+    -- Source: https://www.quasar-store.com/docs/smartphone 
+    local identifier = GetPlayerIdentifier(src, 0)
+    local phoneNumber = exports["qs-smartphone-pro"]:GetPhoneNumberFromIdentifier(identifier, false)
+
+    if not phoneNumber then
+        return false
+    end
+
+    exports["qs-smartphone-pro"]:sendNotification(phoneNumber, {
+        app = "system",
+        head = title,
+        msg = content,
+    }, false)
+
+    return true
+end
+
+return phone

--- a/types/config.lua
+++ b/types/config.lua
@@ -4,13 +4,13 @@
 
 ---@alias AvailableInventories 'ox_inventory' | 'origen_inventory' | 'tgiann-inventory'
 
----@alias AvailablePhones 'lb-phone' | 'yseries' | 'yphone' | 'yflip' | 'npwd' | 'roadphone' | '17mov_phone' | 'gksphone'
+---@alias AvailablePhones 'lb-phone' | 'yseries' | 'yphone' | 'yflip' | 'npwd' | 'roadphone' | '17mov_phone' | 'gksphone' | 'qs-smartphone-pro'
 
 ---@alias AvailableTargets 'ox_target' | 'qb-target' | 'sleepless_interact'
 
 ---@alias AvailableMedicals 'qbx_medical' | 'esx_ambulancejob' | 'wasabi_ambulance' | 'ars_ambulancejob' | 'osp_ambulance' | 'p-ambulancejob' | 'nd_ambulance' | 'qb-ambulancejob' | 'randol_medical' | 'tk_ambulancejob'
 
----@alias AvailableDispatches 'ps-dispatch' | 'origen_police' | 'cd_dispatch' | 'rcore_dispatch' | 'tk_dispatch' | 'lb-tablet' | 'aty_dispatch' | 'codem-dispatch' | 'core_dispatch'
+---@alias AvailableDispatches 'ps-dispatch' | 'origen_police' | 'cd_dispatch' | 'rcore_dispatch' | 'tk_dispatch' | 'lb-tablet' | 'aty_dispatch' | 'codem-dispatch' | 'core_dispatch' | 'qs-dispatch'
 
 ---@alias AvailableMinigames 'prp-minigames'
 


### PR DESCRIPTION
Adds bridge support for two Quasar scripts:
- **qs-dispatch** — new dispatch adapter (`modules/dispatch/qs-dispatch/server.lua`)
- **qs-smartphone-pro** — new phone adapter (`modules/phone/qs-smartphone-pro/server.lua`)
